### PR TITLE
Add filebeat_ssl_insecure variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To generate a self-signed certificate/key pair, you can use use the command:
 
 Note that filebeat and logstash may not work correctly with self-signed certificates unless you also have the full chain of trust (including the Certificate Authority for your self-signed cert) added on your server. See: https://github.com/elastic/logstash/issues/4926#issuecomment-203936891
 
-Variable filebeat_ssl_insecure is available if you are willing to remove certificate checking
+Variable `filebeat_ssl_insecure` is available if you are willing to remove certificate checking
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ To generate a self-signed certificate/key pair, you can use use the command:
 
 Note that filebeat and logstash may not work correctly with self-signed certificates unless you also have the full chain of trust (including the Certificate Authority for your self-signed cert) added on your server. See: https://github.com/elastic/logstash/issues/4926#issuecomment-203936891
 
+Variable filebeat_ssl_insecure is available if you are willing to remove certificate checking
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,3 +15,4 @@ filebeat_output_logstash_hosts:
 filebeat_ssl_dir: /etc/pki/logstash
 filebeat_ssl_certificate_file: ""
 filebeat_ssl_key_file: ""
+filebeat_ssl_insecure: false

--- a/templates/filebeat.yml.j2
+++ b/templates/filebeat.yml.j2
@@ -72,7 +72,7 @@ output:
       # If insecure is set to true, all server host names and certificates will be
       # accepted. In this mode TLS based connections are susceptible to
       # man-in-the-middle attacks. Use only for testing.
-      #insecure: true
+      insecure: {{ filebeat_ssl_insecure }}
 
       # Configure cipher suites to be used for TLS connections
       #cipher_suites: []
@@ -122,6 +122,7 @@ output:
       # accepted. In this mode TLS based connections are susceptible to
       # man-in-the-middle attacks. Use only for testing.
       #insecure: true
+      insecure: {{ filebeat_ssl_insecure }}
 
       # Configure cipher suites to be used for TLS connections
       #cipher_suites: []


### PR DESCRIPTION
Allows Filebeat to send encrypted packets via self-signed certificates (e.g. when a CA isn't available).