### PR TITLE
fixed filebeat_ssl_key_file issue and a typo

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -12,7 +12,7 @@
   file:
     path: "{{ filebeat_ssl_dir }}"
     state: directory
-  when: filebeat_ssl_key_file
+  when: filebeat_ssl_key_file is defined
 
 - name: Copy SSL key and cert for filebeat.
   copy:
@@ -23,4 +23,4 @@
     - "{{ filebeat_ssl_key_file }}"
     - "{{ filebeat_ssl_certificate_file }}"
   notify: restart filebeat
-  when: filebeat_ssl_key_file and filebeat_ssl_certificate_file
+  when: (filebeat_ssl_key_file is defined) and (filebeat_ssl_certificate_file is defined)

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,5 +1,5 @@
 ---
-- name: Ensure depdency is installed (Ubuntu).
+- name: Ensure dependency is installed (Ubuntu).
   apt: name=apt-transport-https state=present
 
 - name: Add Elasticsearch apt key.


### PR DESCRIPTION
When setting filebeat_ssl_key_file in group_vars - I was getting this strange error:

```
The conditional check 'filebeat_ssl_key_file' failed. 
The error was: error while evaluating conditional (filebeat_ssl_key_file): 'filebeat' is undefined
The error appears to have been in 'tasks/config.yml': line 11, column 3
```
This was resolved by checking the variables with 'is defined' (ansible 2.2.1.0 - ubuntu 16.04)

Also fixed a typo... :-)