### PR TITLE
added filebeat_use_own_repo to disable repo config

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Note that filebeat and logstash may not work correctly with self-signed certific
 
 Set this to `"true"` to allow the use of self-signed certificates (when a CA isn't available).
 
+For environments with centralised package management (such as Spacewalk)  set filebeat_use_own_repo:  "True" to disable adding the ElasticSearch repo. 
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,3 +23,4 @@ filebeat_ssl_dir: /etc/pki/logstash
 filebeat_ssl_certificate_file: ""
 filebeat_ssl_key_file: ""
 filebeat_ssl_insecure: "false"
+filebeat_use_own_repo: "false"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,4 +23,4 @@ filebeat_ssl_dir: /etc/pki/logstash
 filebeat_ssl_certificate_file: ""
 filebeat_ssl_key_file: ""
 filebeat_ssl_insecure: "false"
-filebeat_use_own_repo: "false"
+filebeat_use_own_repo: false

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -12,7 +12,7 @@
   file:
     path: "{{ filebeat_ssl_dir }}"
     state: directory
-  when: filebeat_ssl_key_file
+  when: filebeat_ssl_key_file is defined
 
 - name: Copy SSL key and cert for filebeat.
   copy:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - include: setup-RedHat.yml
-  when: ansible_os_family == 'RedHat'
+  when: ansible_os_family == 'RedHat' and not filebeat_use_own_repo
 
 - include: setup-Debian.yml
-  when: ansible_os_family == 'Debian'
+  when: ansible_os_family == 'Debian' and not filebeat_use_own_repo
 
 - name: Install Filebeat.
   package: name=filebeat state=present

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,5 +1,5 @@
 ---
-- name: Ensure depdency is installed (Ubuntu).
+- name: Ensure depedency is installed (Ubuntu).
   apt: name=apt-transport-https state=present
 
 - name: Add Elasticsearch apt key.

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,5 +1,5 @@
 ---
-- name: Ensure depedency is installed (Ubuntu).
+- name: Ensure dependency is installed (Ubuntu).
   apt: name=apt-transport-https state=present
 
 - name: Add Elasticsearch apt key.


### PR DESCRIPTION
added filebeat_use_own_repo to allow parameterised disabling of repo config, corrected spelling mistake and added "is defined" to fix error in config.yml.
