### PR TITLE
Update repo for v 5.x

### DIFF
--- a/templates/beats.repo.j2
+++ b/templates/beats.repo.j2
@@ -1,6 +1,8 @@
-[beats]
-name=Elastic Beats Repository
-baseurl=https://packages.elastic.co/beats/yum/el/$basearch
-enabled=1
-gpgkey=https://packages.elastic.co/GPG-KEY-elasticsearch
+[elastic-5.x]
+name=Elastic repository for 5.x packages
+baseurl=https://artifacts.elastic.co/packages/5.x/yum
 gpgcheck=1
+gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
+enabled=1
+autorefresh=1
+type=rpm-md


### PR DESCRIPTION
The original task gave me a 1/2.x version of filebeat and I didn't notice. This setup is as per official instructions from https://www.elastic.co/guide/en/beats/libbeat/current/setup-repositories.html