### PR TITLE
update repos to 5.x

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -9,6 +9,6 @@
 
 - name: Add Filebeat repository.
   apt_repository:
-    repo: 'deb https://packages.elastic.co/beats/apt stable main'
+    repo: 'deb https://artifacts.elastic.co/packages/5.x/apt stable main'
     state: present
     update_cache: yes

--- a/templates/beats.repo.j2
+++ b/templates/beats.repo.j2
@@ -1,6 +1,8 @@
-[beats]
-name=Elastic Beats Repository
-baseurl=https://packages.elastic.co/beats/yum/el/$basearch
-enabled=1
-gpgkey=https://packages.elastic.co/GPG-KEY-elasticsearch
+[elastic-5.x]
+name=Elastic repository for 5.x packages
+baseurl=https://artifacts.elastic.co/packages/5.x/yum
 gpgcheck=1
+gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
+enabled=1
+autorefresh=1
+type=rpm-md


### PR DESCRIPTION
Elastic has changed their repos for 5.x per https://www.elastic.co/guide/en/beats/libbeat/current/setup-repositories.html