### PR TITLE
Support for SSL with self signed Certificate Authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ To generate a self-signed certificate/key pair, you can use use the command:
 
 Note that filebeat and logstash may not work correctly with self-signed certificates unless you also have the full chain of trust (including the Certificate Authority for your self-signed cert) added on your server. See: https://github.com/elastic/logstash/issues/4926#issuecomment-203936891
 
-    filebeat_ssl_insecure: "false"
+    filebeat_ssl_verification_mode: "full"
 
-Set this to `"true"` to allow the use of self-signed certificates (when a CA isn't available).
+Set this to `"none"` to allow the use of self-signed certificates (when a CA isn't available).
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -44,12 +44,13 @@ Filebeat logging.
 
     filebeat_ssl_dir: /etc/pki/logstash
 
-The path where certificates and keyfiles will be stored.
+The path where CA, certificates and keyfiles will be stored.
 
+    filebeat_ssl_certificate_authority: ""
     filebeat_ssl_certificate_file: ""
     filebeat_ssl_key_file: ""
 
-Local paths to the SSL certificate and key files, which will be copied into the `filebeat_ssl_dir`.
+Local paths to the CA, SSL certificate and key files, which will be copied into the `filebeat_ssl_dir`.
 
 For utmost security, you should use your own valid certificate and keyfile, and update the `filebeat_ssl_*` variables in your playbook to use your certificate.
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ The path where CA, certificates and keyfiles will be stored.
 
 Local paths to the CA, SSL certificate and key files, which will be copied into the `filebeat_ssl_dir`.
 
+    filebeat_ssl: true
+
+Finally, turn on ssl for filebeat.
+
 For utmost security, you should use your own valid certificate and keyfile, and update the `filebeat_ssl_*` variables in your playbook to use your certificate.
 
 To generate a self-signed certificate/key pair, you can use use the command:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,7 @@ filebeat_log_dir: /var/log/mybeat
 filebeat_log_filename: mybeat.log
 
 filebeat_ssl_dir: /etc/pki/logstash
+filebeat_ssl_certificate_authority: ""
 filebeat_ssl_certificate_file: ""
 filebeat_ssl_key_file: ""
 filebeat_ssl_insecure: "false"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,4 +24,4 @@ filebeat_ssl_dir: /etc/pki/logstash
 filebeat_ssl_certificate_authority: ""
 filebeat_ssl_certificate_file: ""
 filebeat_ssl_key_file: ""
-filebeat_ssl_insecure: "false"
+filebeat_ssl_verification_mode: "full"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,7 @@ filebeat_log_level: warning
 filebeat_log_dir: /var/log/mybeat
 filebeat_log_filename: mybeat.log
 
+filebeat_ssl: false
 filebeat_ssl_dir: /etc/pki/logstash
 filebeat_ssl_certificate_authority: ""
 filebeat_ssl_certificate_file: ""

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -22,5 +22,6 @@
   with_items:
     - "{{ filebeat_ssl_key_file }}"
     - "{{ filebeat_ssl_certificate_file }}"
+    - "{{ filebeat_ssl_certificate_authority }}"
   notify: restart filebeat
   when: filebeat_ssl_key_file and filebeat_ssl_certificate_file

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -12,7 +12,7 @@
   file:
     path: "{{ filebeat_ssl_dir }}"
     state: directory
-  when: filebeat_ssl_key_file
+  when: filebeat_ssl
 
 - name: Copy SSL key and cert for filebeat.
   copy:
@@ -24,4 +24,4 @@
     - "{{ filebeat_ssl_certificate_file }}"
     - "{{ filebeat_ssl_certificate_authority }}"
   notify: restart filebeat
-  when: filebeat_ssl_key_file and filebeat_ssl_certificate_file
+  when: filebeat_ssl

--- a/templates/filebeat.yml.j2
+++ b/templates/filebeat.yml.j2
@@ -58,7 +58,7 @@ output:
 
 {% if filebeat_ssl %}
     # tls configuration. By default is off.
-    tls:
+    ssl:
       # List of root certificates for HTTPS server verifications
       certificate_authorities: ["{{ filebeat_ssl_dir }}/{{ filebeat_ssl_certificate_authority | basename }}"]
 
@@ -66,13 +66,10 @@ output:
       certificate: "{{ filebeat_ssl_dir }}/{{ filebeat_ssl_certificate_file | basename }}"
 
       # Client Certificate Key
-      certificate_key: "{{ filebeat_ssl_dir }}/{{ filebeat_ssl_key_file | basename}}"
+      key: "{{ filebeat_ssl_dir }}/{{ filebeat_ssl_key_file | basename}}"
 
       # Controls whether the client verifies server certificates and host name.
-      # If insecure is set to true, all server host names and certificates will be
-      # accepted. In this mode TLS based connections are susceptible to
-      # man-in-the-middle attacks. Use only for testing.
-      insecure: {{ filebeat_ssl_insecure }}
+      verification_mode: {{ filebeat_ssl_verification_mode }}
 
       # Configure cipher suites to be used for TLS connections
       #cipher_suites: []
@@ -80,11 +77,8 @@ output:
       # Configure curve types for ECDHE based cipher suites
       #curve_types: []
 
-      # Configure minimum TLS version allowed for connection to logstash
-      #min_version: 1.0
-
-      # Configure maximum TLS version allowed for connection to logstash
-      #max_version: 1.2
+      # Configure TLS protocols allowed for connection to logstash
+      #supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 {% endif %}
 {% endif %}
 
@@ -107,7 +101,7 @@ output:
 
 {% if filebeat_ssl %}
     # Optional TLS. By default is off.
-    tls:
+    ssl:
       # List of root certificates for HTTPS server verifications
       certificate_authorities: ["{{ filebeat_ssl_dir }}/{{ filebeat_ssl_certificate_authority | basename }}"]
 
@@ -115,20 +109,19 @@ output:
       certificate: "{{ filebeat_ssl_dir }}/{{ filebeat_ssl_certificate_file | basename }}"
 
       # Client Certificate Key
-      certificate_key: "{{ filebeat_ssl_dir }}/{{ filebeat_ssl_key_file | basename}}"
+      key: "{{ filebeat_ssl_dir }}/{{ filebeat_ssl_key_file | basename}}"
 
       # Controls whether the client verifies server certificates and host name.
-      # If insecure is set to true, all server host names and certificates will be
-      # accepted. In this mode TLS based connections are susceptible to
-      # man-in-the-middle attacks. Use only for testing.
-      #insecure: true
-      insecure: {{ filebeat_ssl_insecure }}
+      verification_mode: {{ filebeat_ssl_verification_mode }}
 
       # Configure cipher suites to be used for TLS connections
       #cipher_suites: []
 
       # Configure curve types for ECDHE based cipher suites
       #curve_types: []
+
+      # Configure TLS protocols allowed for connection to logstash
+      #supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 {% endif %}
 
 {% if filebeat_enable_logging %}

--- a/templates/filebeat.yml.j2
+++ b/templates/filebeat.yml.j2
@@ -60,7 +60,7 @@ output:
     # tls configuration. By default is off.
     tls:
       # List of root certificates for HTTPS server verifications
-      #certificate_authorities: ["/etc/pki/root/ca.pem"]
+      certificate_authorities: ["{{ filebeat_ssl_dir }}/{{ filebeat_ssl_certificate_authority | basename }}"]
 
       # Certificate for TLS client authentication
       certificate: "{{ filebeat_ssl_dir }}/{{ filebeat_ssl_certificate_file | basename }}"
@@ -109,7 +109,7 @@ output:
     # Optional TLS. By default is off.
     tls:
       # List of root certificates for HTTPS server verifications
-      #certificate_authorities: ["/etc/pki/root/ca.pem"]
+      certificate_authorities: ["{{ filebeat_ssl_dir }}/{{ filebeat_ssl_certificate_authority | basename }}"]
 
       # Certificate for TLS client authentication
       certificate: "{{ filebeat_ssl_dir }}/{{ filebeat_ssl_certificate_file | basename }}"

--- a/templates/filebeat.yml.j2
+++ b/templates/filebeat.yml.j2
@@ -56,7 +56,7 @@ output:
     # Elasticsearch. The default is 15 seconds.
     #topology_expire: 15
 
-{% if filebeat_ssl_certificate_file and filebeat_ssl_key_file %}
+{% if filebeat_ssl %}
     # tls configuration. By default is off.
     tls:
       # List of root certificates for HTTPS server verifications
@@ -105,7 +105,7 @@ output:
     # top topbeat and for Filebeat to filebeat.
     #index: filebeat
 
-{% if filebeat_ssl_certificate_file and filebeat_ssl_key_file %}
+{% if filebeat_ssl %}
     # Optional TLS. By default is off.
     tls:
       # List of root certificates for HTTPS server verifications


### PR DESCRIPTION
Related to https://github.com/geerlingguy/ansible-role-logstash/pull/33

I've been playing around to get a secured connection between Filebeat and Logstash.

I've setup a self signed CA for this and use the `filebeat_ssl_certificate_authority` directive to include it. I guess it would be cleaner to have list of CAs instead of one, but I can't wrap my head around on how to get that into the Jinja template. Feel free to give suggestions.

I've also done a few other changes, please check the individual commits.