### PR TITLE
Allow to specify certificate authorities

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Note that filebeat and logstash may not work correctly with self-signed certific
 
 Set this to `"true"` to allow the use of self-signed certificates (when a CA isn't available).
 
+    filebeat_ssl_ca: ["/etc/pki/root/ca.pem"]
+
+Configures Filebeat to trust any certificates signed by the specified CA. Please refer to [Secure communication with Logstash by using SSL]( https://www.elastic.co/guide/en/beats/filebeat/current/configuring-ssl-logstash.html#configuring-ssl-logstash) for more details.
+
 ## Dependencies
 
 None.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Note that filebeat and logstash may not work correctly with self-signed certific
 
 Set this to `"true"` to allow the use of self-signed certificates (when a CA isn't available).
 
-    filebeat_ssl_ca: ["/etc/pki/root/ca.pem"]
+    filebeat_ssl_ca: []
 
 Configures Filebeat to trust any certificates signed by the specified CA. Please refer to [Secure communication with Logstash by using SSL]( https://www.elastic.co/guide/en/beats/filebeat/current/configuring-ssl-logstash.html#configuring-ssl-logstash) for more details.
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Note that filebeat and logstash may not work correctly with self-signed certific
 
 Set this to `"true"` to allow the use of self-signed certificates (when a CA isn't available).
 
-    filebeat_ssl_ca: []
+    filebeat_ssl_ca:
 
 Configures Filebeat to trust any certificates signed by the specified CA. Please refer to [Secure communication with Logstash by using SSL]( https://www.elastic.co/guide/en/beats/filebeat/current/configuring-ssl-logstash.html#configuring-ssl-logstash) for more details.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,3 +23,4 @@ filebeat_ssl_dir: /etc/pki/logstash
 filebeat_ssl_certificate_file: ""
 filebeat_ssl_key_file: ""
 filebeat_ssl_insecure: "false"
+filebeat_ssl_ca: ["/etc/pki/root/ca.pem"]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,4 +23,4 @@ filebeat_ssl_dir: /etc/pki/logstash
 filebeat_ssl_certificate_file: ""
 filebeat_ssl_key_file: ""
 filebeat_ssl_insecure: "false"
-filebeat_ssl_ca: ["/etc/pki/root/ca.pem"]
+filebeat_ssl_ca: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,4 +23,4 @@ filebeat_ssl_dir: /etc/pki/logstash
 filebeat_ssl_certificate_file: ""
 filebeat_ssl_key_file: ""
 filebeat_ssl_insecure: "false"
-filebeat_ssl_ca: []
+filebeat_ssl_ca:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -24,3 +24,12 @@
     - "{{ filebeat_ssl_certificate_file }}"
   notify: restart filebeat
   when: filebeat_ssl_key_file and filebeat_ssl_certificate_file
+
+- name: Copy CA.
+  copy:
+    src: "{{ item }}"
+    dest: "{{ filebeat_ssl_dir }}/{{ item | basename }}"
+    mode: 0644
+  with_items: "{{ filebeat_ssl_ca }}"
+  notify: restart filebeat
+  when: filebeat_ssl_ca

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -25,10 +25,16 @@
   notify: restart filebeat
   when: filebeat_ssl_key_file and filebeat_ssl_certificate_file
 
+- name: Ensure Filebeat CA directory exists.
+  file:
+    path: "{{ filebeat_ssl_dir }}/ca"
+    state: directory
+  when: filebeat_ssl_ca
+
 - name: Copy CA.
   copy:
     src: "{{ item }}"
-    dest: "{{ filebeat_ssl_dir }}/{{ item | basename }}"
+    dest: "{{ filebeat_ssl_dir }}/ca/{{ item | basename }}"
     mode: 0644
   with_items: "{{ filebeat_ssl_ca }}"
   notify: restart filebeat

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -25,16 +25,26 @@
   notify: restart filebeat
   when: filebeat_ssl_key_file and filebeat_ssl_certificate_file
 
+- name: Define filebeat_ssl_ca_dir.
+  set_fact:
+    filebeat_ssl_ca_dir: "{{ filebeat_ssl_dir }}/ca"
+  when: filebeat_ssl_ca
+
 - name: Ensure Filebeat CA directory exists.
   file:
-    path: "{{ filebeat_ssl_dir }}/ca"
+    path: "{{ filebeat_ssl_ca_dir }}"
     state: directory
+  when: filebeat_ssl_ca
+
+- name: Define filebeat_ssl_ca_basenames.
+  set_fact:
+    filebeat_ssl_ca_basenames: "{{ filebeat_ssl_ca | map('basename') | list }}"
   when: filebeat_ssl_ca
 
 - name: Copy CA.
   copy:
     src: "{{ item }}"
-    dest: "{{ filebeat_ssl_dir }}/ca/{{ item | basename }}"
+    dest: "{{ filebeat_ssl_ca_dir }}/{{ item | basename }}"
     mode: 0644
   with_items: "{{ filebeat_ssl_ca }}"
   notify: restart filebeat

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -1,4 +1,14 @@
 ---
+- name: Define filebeat_ssl_ca_dir.
+  set_fact:
+    filebeat_ssl_ca_dir: "{{ filebeat_ssl_dir }}/ca"
+  when: filebeat_ssl_ca
+
+- name: Define filebeat_ssl_ca_basenames.
+  set_fact:
+    filebeat_ssl_ca_basenames: "{{ filebeat_ssl_ca | map('basename') | list }}"
+  when: filebeat_ssl_ca
+
 - name: Copy Filebeat configuration.
   template:
     src: filebeat.yml.j2
@@ -25,20 +35,10 @@
   notify: restart filebeat
   when: filebeat_ssl_key_file and filebeat_ssl_certificate_file
 
-- name: Define filebeat_ssl_ca_dir.
-  set_fact:
-    filebeat_ssl_ca_dir: "{{ filebeat_ssl_dir }}/ca"
-  when: filebeat_ssl_ca
-
 - name: Ensure Filebeat CA directory exists.
   file:
     path: "{{ filebeat_ssl_ca_dir }}"
     state: directory
-  when: filebeat_ssl_ca
-
-- name: Define filebeat_ssl_ca_basenames.
-  set_fact:
-    filebeat_ssl_ca_basenames: "{{ filebeat_ssl_ca | map('basename') | list }}"
   when: filebeat_ssl_ca
 
 - name: Copy CA.

--- a/templates/filebeat.yml.j2
+++ b/templates/filebeat.yml.j2
@@ -60,7 +60,7 @@ output:
     # tls configuration. By default is off.
     tls:
       # List of root certificates for HTTPS server verifications
-      #certificate_authorities: ["/etc/pki/root/ca.pem"]
+      certificate_authorities: {{ filebeat_ssl_ca }}
 
       # Certificate for TLS client authentication
       certificate: "{{ filebeat_ssl_dir }}/{{ filebeat_ssl_certificate_file | basename }}"
@@ -109,7 +109,7 @@ output:
     # Optional TLS. By default is off.
     tls:
       # List of root certificates for HTTPS server verifications
-      #certificate_authorities: ["/etc/pki/root/ca.pem"]
+      certificate_authorities: {{ filebeat_ssl_ca }}
 
       # Certificate for TLS client authentication
       certificate: "{{ filebeat_ssl_dir }}/{{ filebeat_ssl_certificate_file | basename }}"

--- a/templates/filebeat.yml.j2
+++ b/templates/filebeat.yml.j2
@@ -109,7 +109,9 @@ output:
     # Optional TLS. By default is off.
     tls:
       # List of root certificates for HTTPS server verifications
-      certificate_authorities: {{ filebeat_ssl_ca }}
+      {% if filebeat_ssl_ca %}
+        certificate_authorities: {{ filebeat_ssl_ca | to_json}}
+      {% endif %}
 
       # Certificate for TLS client authentication
       certificate: "{{ filebeat_ssl_dir }}/{{ filebeat_ssl_certificate_file | basename }}"

--- a/templates/filebeat.yml.j2
+++ b/templates/filebeat.yml.j2
@@ -61,7 +61,7 @@ output:
     tls:
       # List of root certificates for HTTPS server verifications
       {% if filebeat_ssl_ca %}
-        certificate_authorities: {{ filebeat_ssl_ca | to_json}}
+        certificate_authorities: {{ [filebeat_ssl_ca_dir] | zip_longest(filebeat_ssl_ca_basenames, fillvalue=filebeat_ssl_ca_dir) | map('join') | list | to_json }}
       {% endif %}
 
       # Certificate for TLS client authentication
@@ -112,7 +112,7 @@ output:
     tls:
       # List of root certificates for HTTPS server verifications
       {% if filebeat_ssl_ca %}
-        certificate_authorities: {{ filebeat_ssl_ca | to_json}}
+        certificate_authorities: {{ [filebeat_ssl_ca_dir] | zip_longest(filebeat_ssl_ca_basenames, fillvalue=filebeat_ssl_ca_dir) | map('join') | list | to_json }}
       {% endif %}
 
       # Certificate for TLS client authentication

--- a/templates/filebeat.yml.j2
+++ b/templates/filebeat.yml.j2
@@ -60,7 +60,9 @@ output:
     # tls configuration. By default is off.
     tls:
       # List of root certificates for HTTPS server verifications
-      certificate_authorities: {{ filebeat_ssl_ca }}
+      {% if filebeat_ssl_ca %}
+        certificate_authorities: {{ filebeat_ssl_ca | to_json}}
+      {% endif %}
 
       # Certificate for TLS client authentication
       certificate: "{{ filebeat_ssl_dir }}/{{ filebeat_ssl_certificate_file | basename }}"


### PR DESCRIPTION
This might be helpful if you want to use a separate CA for certificate validation between Filebeat and Logstash.