### PR TITLE
Bump version, introduce HTTP authentication support and custom index name 

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ It's possible for you to define your own index name, but if you do, you'll have 
     filebeat_elasticsearch_index_name: "filebeat"
     filebeat_custom_template_enabled: "true"
     filebeat_custom_template_name: "custom-template" 
-    filebeat_custom_template_pattern: ""
     filebeat_custom_template_pattern: "custom-template-%{[beat.version]}-*"
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ Note that filebeat and logstash may not work correctly with self-signed certific
 
 Set this to `"true"` to allow the use of self-signed certificates (when a CA isn't available).
 
+It's possible to include the usage of basic HTTP authentication too:
+
+    filebeat_basic_auth_enabled: "true"
+    filebeat_elasticsearch_username: "username"
+    filebeat_elasticsearch_password: "password"
+
+It's possible for you to define your own index name, but if you do, you'll have to create a specific template around it otherwise filebeat will not start. This is done via a template and will use HTTPS as the protocol. You can configure this via variables.
+
+    filebeat_elasticsearch_index_name: "filebeat"
+    filebeat_custom_template_enabled: "true"
+    filebeat_custom_template_name: "custom-template" 
+    filebeat_custom_template_pattern: ""
+    filebeat_custom_template_pattern: "custom-template-%{[beat.version]}-*"
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,16 @@ filebeat_output_elasticsearch_enabled: false
 filebeat_output_elasticsearch_hosts:
   - "localhost:9200"
 
+filebeat_basic_auth_enabled: false
+filebeat_elasticsearch_username: ''
+filebeat_elasticsearch_password: ''
+
+filebeat_elasticsearch_index_name: filebeat
+
+filebeat_custom_template_enabled: true
+filebeat_custom_template_name: ''
+filebeat_custom_template_pattern: ''
+
 filebeat_output_logstash_enabled: true
 filebeat_output_logstash_hosts:
   - "localhost:5044"

--- a/templates/beats.repo.j2
+++ b/templates/beats.repo.j2
@@ -1,6 +1,6 @@
-[elastic-5.x]
-name=Elastic repository for 5.x packages
-baseurl=https://artifacts.elastic.co/packages/5.x/yum
+[elasticsearch-6.x]
+name=Elasticsearch repository for 6.x packages
+baseurl=https://artifacts.elastic.co/packages/6.x/yum
 gpgcheck=1
 gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
 enabled=1

--- a/templates/filebeat.yml.j2
+++ b/templates/filebeat.yml.j2
@@ -3,6 +3,13 @@ filebeat:
   prospectors:
     {{ filebeat_prospectors | to_json }}
 
+{% if filebeat_custom_template_enabled %}
+setup.template.enabled: true
+setup.template.overwrite: true
+setup.template.name: {{ filebeat_custom_template_name }}
+setup.template.pattern: {{ filebeat_custom_template_pattern }}
+{% endif %}
+
 # Configure what outputs to use when sending the data collected by the beat.
 # Multiple outputs may be used.
 output:
@@ -13,17 +20,20 @@ output:
     # Array of hosts to connect to.
     hosts: {{ filebeat_output_elasticsearch_hosts | to_json }}
 
-    # Optional protocol and basic auth credentials. These are deprecated.
-    #protocol: "https"
-    #username: "admin"
-    #password: "s3cr3t"
+    # HTTPS basic auth
+    {% if filebeat_basic_auth_enabled %}
+
+    protocol: "https"
+    username: "{{ filebeat_elasticsearch_username }}"
+    password: "{{ filebeat_elasticsearch_password }}"
+    {% endif %}
 
     # Number of workers per Elasticsearch host.
     #worker: 1
 
     # Optional index name. The default is "filebeat" and generates
     # [filebeat-]YYYY.MM.DD keys.
-    #index: "filebeat"
+    index: "{{ filebeat_elasticsearch_index_name }}"
 
     # Optional HTTP Path
     #path: "/elasticsearch"


### PR DESCRIPTION
Hey everyone,

To work with our ES cluster here I had to make some changes around this which I think are beneficial to push back.

- Update FB to 6 (change the repository)
- We use a signed certificate, and mainly stay within DC via interconnects, so we are able to use HTTPS authentication. I added support to enable this and define a username/password
- We are also required to specify an index name, as this is tied to the above created service account. On the defining of an index name, you need to specify a template, or FB will not start. Therefore, I added the ability for you to define this via variables.

Let me know if you all think there is any more work can be done around this, or if there are any drawbacks!