### PR TITLE
Renaming prospectors to inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ Controls the major version of Filebeat which is installed.
 
 Whether to create the Filebeat configuration file and handle the copying of SSL key and cert for filebeat. If you prefer to create a configuration file yourself you can set this to `false`.
 
-    filebeat_prospectors:
+    filebeat_inputs:
       - input_type: log
         paths:
           - "/var/log/*.log"
 
-Prospectors that will be listed in the `prospectors` section of the Filebeat configuration. Read through the [Filebeat Prospectors configuration guide](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-filebeat-options.html) for more options.
+Inputs that will be listed in the `inputs` section of the Filebeat configuration. Read through the [Filebeat Inputs configuration guide](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-filebeat-options.html) for more options.
 
     filebeat_output_elasticsearch_enabled: false
     filebeat_output_elasticsearch_hosts:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 filebeat_version: 6.x
 filebeat_create_config: true
 
-filebeat_prospectors:
+filebeat_inputs:
   - input_type: log
     paths:
       - "/var/log/*.log"

--- a/templates/filebeat.yml.j2
+++ b/templates/filebeat.yml.j2
@@ -1,7 +1,7 @@
 filebeat:
-  # List of prospectors to fetch data.
-  prospectors:
-    {{ filebeat_prospectors | to_json }}
+  # List of inputs to fetch data.
+  inputs:
+    {{ filebeat_inputs | to_json }}
 
 # Configure what outputs to use when sending the data collected by the beat.
 # Multiple outputs may be used.


### PR DESCRIPTION
Prospectors have been deprecated. Updating them to inputs.