### PR TITLE
Add `| length > 0` after 'filebeat_ssl_key_file'

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -12,7 +12,7 @@
   file:
     path: "{{ filebeat_ssl_dir }}"
     state: directory
-  when: filebeat_ssl_key_file is defined
+  when: filebeat_ssl_key_file | length > 0
 
 - name: Copy SSL key and cert for filebeat.
   copy:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -12,7 +12,7 @@
   file:
     path: "{{ filebeat_ssl_dir }}"
     state: directory
-  when: filebeat_ssl_key_file
+  when: filebeat_ssl_key_file is defined
 
 - name: Copy SSL key and cert for filebeat.
   copy:


### PR DESCRIPTION
Related to https://github.com/geerlingguy/ansible-role-logstash/pull/48

If you don't have this it causes the same issue.

```
TASK [geerlingguy.filebeat : Ensure Filebeat SSL key pair directory exists.] ***************************************************************************************************
fatal: [localhost]: FAILED! => {"msg": "The conditional check 'filebeat_ssl_key_file' failed. The error was: error while evaluating conditional (filebeat_ssl_key_file): 'filebeat' is undefined\n\nThe error appears to have been in '/home/user/.ansible/roles/geerlingguy.filebeat/tasks/config.yml': line 11, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Ensure Filebeat SSL key pair directory exists.\n  ^ here\n"}
```