### PR TITLE
Add `when` conditionals to check for architecture

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,18 +1,26 @@
 ---
 - include: setup-RedHat.yml
-  when: ansible_os_family == 'RedHat'
+  when: 
+    - ansible_os_family == 'RedHat'
+    - ansible_architecture == "x86_64" or ansible_architecture == "i386" or ansible_architecture == "i686"
 
 - include: setup-Debian.yml
-  when: ansible_os_family == 'Debian'
+  when: 
+    - ansible_os_family == 'Debian'
+    - ansible_architecture == "x86_64" or ansible_architecture == "i386" or ansible_architecture == "i686"
 
 - name: Install Filebeat.
   package: name=filebeat state=present
+  when: ansible_architecture == "x86_64" or ansible_architecture == "i386" or ansible_architecture == "i686"
 
 - include: config.yml
-  when: filebeat_create_config
+  when: 
+    - filebeat_create_config
+    - ansible_architecture == "x86_64" or ansible_architecture == "i386" or ansible_architecture == "i686"
 
 - name: Ensure Filebeat is started and enabled at boot.
   service:
     name: filebeat
     state: started
     enabled: true
+  when: ansible_architecture == "x86_64" or ansible_architecture == "i386" or ansible_architecture == "i686"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 - include: setup-RedHat.yml
-  when: 
+  when:
     - ansible_os_family == 'RedHat'
     - ansible_architecture == "x86_64" or ansible_architecture == "i386" or ansible_architecture == "i686"
 
 - include: setup-Debian.yml
-  when: 
+  when:
     - ansible_os_family == 'Debian'
     - ansible_architecture == "x86_64" or ansible_architecture == "i386" or ansible_architecture == "i686"
 
@@ -14,7 +14,7 @@
   when: ansible_architecture == "x86_64" or ansible_architecture == "i386" or ansible_architecture == "i686"
 
 - include: config.yml
-  when: 
+  when:
     - filebeat_create_config
     - ansible_architecture == "x86_64" or ansible_architecture == "i386" or ansible_architecture == "i686"
 


### PR DESCRIPTION
Filebeat doesn't support anything but x86_64, i386 (DEB) and i686 (RPM). Added conditionals to check for that before doing anything. If you run this Ansible role on an ARMv7 server for example it will add the repository breaking your package manager. Adding these checks helps as it'll skip everything that Filebeat doesn't support.