### PR TITLE
CONDITIONAL_BARE_VARS deprecation fix in when condition

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -12,7 +12,7 @@
   file:
     path: "{{ filebeat_ssl_dir }}"
     state: directory
-  when: filebeat_ssl_key_file
+  when: filebeat_ssl_key_file | bool
 
 - name: Copy SSL key and cert for filebeat.
   copy:


### PR DESCRIPTION
Fixes the `CONDITIONAL_BARE_VARS` warning

> TASK [filebeat : Ensure Filebeat SSL key pair directory exists.] ********************************************************************************************************************
> task path: /home/sysadmin/ansible-playbook/roles/filebeat/tasks/config.yml:11
> [DEPRECATION WARNING]: evaluating filebeat_ssl_key_file as a bare variable, this behaviour will go away and you might need to add |bool to the expression in the future. Also see 
> CONDITIONAL_BARE_VARS configuration toggle.. This feature will be removed in version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in 
> ansible.cfg.