### PR TITLE
Logstash : add more template options for logstash and enable logstash modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ Whether to enable Elasticsearch output, and which hosts to send output to.
     filebeat_output_logstash_hosts:
       - "localhost:5000"
 
+In case you have credentials and add additional options
+
+    filebeat_output_logstash_opts:
+      index: "filebeat-${HOST}"
+      username: my_elastic_user
+      password: super_hard_secret
+
 Whether to enable Logstash output, and which hosts to send output to.
 
     filebeat_enable_logging: false

--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ Note that filebeat and logstash may not work correctly with self-signed certific
 
 Set this to `"true"` to allow the use of self-signed certificates (when a CA isn't available).
 
+Modules: to enable use these variables:
+
+    filebeat_enable_modules: true
+    filebeat_modules: [nginx,mysql,iptables]
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 filebeat_version: 7.x
 filebeat_create_config: true
 filebeat_enable_modules: false
+filebeat_modules: []
 
 filebeat_inputs:
   - type: log

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,7 @@ filebeat_log_level: warning
 filebeat_log_dir: /var/log/mybeat
 filebeat_log_filename: mybeat.log
 
+filebeat_config_path: /etc/filebeat/filebeat.yml
 filebeat_ssl_dir: /etc/pki/logstash
 filebeat_ssl_certificate_file: ""
 filebeat_ssl_key_file: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 filebeat_version: 7.x
 filebeat_create_config: true
+filebeat_enable_modules: false
 
 filebeat_inputs:
   - type: log

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -2,7 +2,7 @@
 - name: Copy Filebeat configuration.
   template:
     src: filebeat.yml.j2
-    dest: "/etc/filebeat/filebeat.yml"
+    dest: "{{ filebeat_config_path }}"
     owner: root
     group: root
     mode: 0644

--- a/tasks/enable_modules.yml
+++ b/tasks/enable_modules.yml
@@ -2,7 +2,5 @@
 - name: Enable filebeat modules
   shell:
     cmd: filebeat modules enable {{item}}
-  with_items:
-    - nginx
-    - mysql
-    - iptables
+  with_items: "{{ filebeat_modules }}"
+

--- a/tasks/enable_modules.yml
+++ b/tasks/enable_modules.yml
@@ -1,0 +1,8 @@
+---
+- name: Enable filebeat modules
+  shell:
+    cmd: filebeat modules enable {{item}}
+  with_items:
+    - nginx
+    - mysql
+    - iptables

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,10 @@
   when: filebeat_create_config | bool
   tags: [copy_filebeat_config]
 
+- include: enable_modules.yml
+  when: filebeat_enable_modules | bool
+  tags: [enable_filebeat_module]
+  
 - name: Ensure Filebeat is started and enabled at boot.
   service:
     name: filebeat

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,7 @@
 
 - include: config.yml
   when: filebeat_create_config | bool
+  tags: [copy_filebeat_config]
 
 - name: Ensure Filebeat is started and enabled at boot.
   service:

--- a/templates/filebeat.yml.j2
+++ b/templates/filebeat.yml.j2
@@ -1,3 +1,4 @@
+#jinja2: lstrip_blocks: "True"
 filebeat:
   # List of inputs.
   inputs:
@@ -93,13 +94,11 @@ output:
   logstash:
     # The Logstash hosts
     hosts: {{ filebeat_output_logstash_hosts | to_json }}
-  {% if filebeat_output_logstash_username is defined %}
-    username: {{ filebeat_output_logstash_username }}
+  {% if filebeat_output_logstash_opts is defined -%}
+    {% for item, value in filebeat_output_logstash_opts.items() %}
+    {{ item }}: {{ value }}
+    {% endfor %}
   {% endif %}
-  {% if filebeat_output_logstash_password is defined %}
-    password: {{ filebeat_output_logstash_password }}
-  {% endif %}
-
     # Number of workers per Logstash host.
     #worker: 1
 
@@ -109,9 +108,6 @@ output:
     # Optional index name. The default index name depends on the each beat.
     # For Packetbeat, the default is set to packetbeat, for Topbeat
     # top topbeat and for Filebeat to filebeat.
-  {% if filebeat_output_logstash_index is defined %}
-    index: {{ filebeat_output_logstash_index }}
-  {% endif %}
 
 
 {% if filebeat_ssl_certificate_file and filebeat_ssl_key_file %}

--- a/templates/filebeat.yml.j2
+++ b/templates/filebeat.yml.j2
@@ -152,3 +152,15 @@ logging:
     keepfiles: 7
 {% endif %}
 {% endif %}
+
+# filebeat modules
+filebeat.config.modules:
+  # Glob pattern for configuration loading
+  path: ${path.config}/modules.d/*.yml
+
+  # Set to true to enable config reloading
+  reload.enabled: false
+
+  # Period on which files under path should be checked for changes
+  reload.period: 30s
+

--- a/templates/filebeat.yml.j2
+++ b/templates/filebeat.yml.j2
@@ -93,6 +93,12 @@ output:
   logstash:
     # The Logstash hosts
     hosts: {{ filebeat_output_logstash_hosts | to_json }}
+  {% if filebeat_output_logstash_username is defined %}
+    username: {{ filebeat_output_logstash_username }}
+  {% endif %}
+  {% if filebeat_output_logstash_password is defined %}
+    password: {{ filebeat_output_logstash_password }}
+  {% endif %}
 
     # Number of workers per Logstash host.
     #worker: 1
@@ -103,7 +109,10 @@ output:
     # Optional index name. The default index name depends on the each beat.
     # For Packetbeat, the default is set to packetbeat, for Topbeat
     # top topbeat and for Filebeat to filebeat.
-    #index: filebeat
+  {% if filebeat_output_logstash_index is defined %}
+    index: {{ filebeat_output_logstash_index }}
+  {% endif %}
+
 
 {% if filebeat_ssl_certificate_file and filebeat_ssl_key_file %}
     # ssl configuration. By default is off.


### PR DESCRIPTION
**Description**
This pr is created to support more logstash options on filebeat configuration.

With this, one can specify multiple options for logstash with variable: `filebeat_output_logstash_opts`:
```yaml
    filebeat_output_logstash_opts:
      index: "filebeat-${USER}"
      username: my_elastic_user
      password: super_hard_secret
```

In addition, support for enabling modules added with variables:
```yaml
    filebeat_enable_modules: true
    filebeat_modules: [nginx,mysql,iptables]
```