### PR TITLE
Add support for file output.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,14 @@ filebeat_output_logstash_enabled: true
 filebeat_output_logstash_hosts:
   - "localhost:5044"
 
+
+filebeat_output_file_enabled: false
+filebeat_output_file_path: ""
+filebeat_output_file_filename: ""
+filebeat_output_file_rotate_every_kb: "10240"
+filebeat_output_file_number_of_files: "7"
+filebeat_output_file_permissions: "0600"
+
 filebeat_enable_logging: false
 filebeat_log_level: warning
 filebeat_log_dir: /var/log/mybeat

--- a/templates/filebeat.yml.j2
+++ b/templates/filebeat.yml.j2
@@ -131,6 +131,15 @@ output:
 {% endif %}
 {% endif %}
 
+{% if filebeat_output_file_enabled %}
+  file:
+    path: {{ filebeat_output_file_path }}
+    filename: {{ filebeat_output_file_filename }}
+    rotate_every_kb: {{ filebeat_output_file_rotate_every_kb }}
+    number_of_files: {{ filebeat_output_file_number_of_files }}
+    permissions: {{ filebeat_output_file_permissions }}
+{% endif %}
+
 {% if filebeat_enable_logging %}
 logging:
   ### Filebeat log

--- a/templates/filebeat.yml.j2
+++ b/templates/filebeat.yml.j2
@@ -129,6 +129,7 @@ output:
       # Configure curve types for ECDHE based cipher suites
       #curve_types: []
 {% endif %}
+{% endif %}
 
 {% if filebeat_enable_logging %}
 logging:
@@ -145,5 +146,4 @@ logging:
     path: {{ filebeat_log_dir }}
     name: {{ filebeat_log_filename }}
     keepfiles: 7
-{% endif %}
 {% endif %}


### PR DESCRIPTION
Extending filebeat role to support configuring output as a file. The work was done based on the documentation provided by elastic:
https://www.elastic.co/guide/en/beats/filebeat/current/file-output.html