### PR TITLE
Allow authentication for elasticsearch output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ Inputs that will be listed in the `inputs` section of the Filebeat configuration
 
 Whether to enable Elasticsearch output, and which hosts to send output to.
 
+    filebeat_output_elasticsearch_auth:
+        username: "admin"
+        username: "S3CR3eeet"
+
+    # or, only for version 8+
+    filebeat_output_elasticsearch_auth:
+        api_key: "xa-123a-f3ea012d-aaae1"
+
+Configures the authentication for the elasticsearch output. Note that api_key and user/pass are mutually exclusive, andd api_key is only available from version 8.
+
     filebeat_output_logstash_enabled: true
     filebeat_output_logstash_hosts:
       - "localhost:5000"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,8 @@ filebeat_output_elasticsearch_enabled: false
 filebeat_output_elasticsearch_hosts:
   - "localhost:9200"
 
+filebeat_output_elasticsearch_auth: {}
+
 filebeat_output_logstash_enabled: true
 filebeat_output_logstash_hosts:
   - "localhost:5044"

--- a/templates/filebeat.yml.j2
+++ b/templates/filebeat.yml.j2
@@ -15,12 +15,12 @@ output:
 
     # Optional auth via API Key or username/password.
     # The options are mutually exclusive and api_key takes the precedence.
-    {% if 'api_key' in filebeat_output_elasticsearch_auth %}
+    {%- if 'api_key' in filebeat_output_elasticsearch_auth %}
     api_key: "{{ filebeat_output_elasticsearch_auth.api_key }}"
-    {% elif 'username' in filebeat_output_elasticsearch_auth %}
+    {%- elif 'username' in filebeat_output_elasticsearch_auth %}
     username: "{{ filebeat_output_elasticsearch_auth.username }}"
     password: "{{ filebeat_output_elasticsearch_auth.password }}"
-    {% endif %}
+    {%- endif %}
 
     # Number of workers per Elasticsearch host.
     #worker: 1

--- a/templates/filebeat.yml.j2
+++ b/templates/filebeat.yml.j2
@@ -13,10 +13,14 @@ output:
     # Array of hosts to connect to.
     hosts: {{ filebeat_output_elasticsearch_hosts | to_json }}
 
-    # Optional protocol and basic auth credentials. These are deprecated.
-    #protocol: "https"
-    #username: "admin"
-    #password: "s3cr3t"
+    # Optional auth via API Key or username/password.
+    # The options are mutually exclusive and api_key takes the precedence.
+    {% if 'api_key' in filebeat_output_elasticsearch_auth %}
+    api_key: "{{ filebeat_output_elasticsearch_auth.api_key }}"
+    {% elif 'username' in filebeat_output_elasticsearch_auth %}
+    username: "{{ filebeat_output_elasticsearch_auth.username }}"
+    password: "{{ filebeat_output_elasticsearch_auth.password }}"
+    {% endif %}
 
     # Number of workers per Elasticsearch host.
     #worker: 1


### PR DESCRIPTION
This PR introduces the support for authentication on the Elasticsearch output.

The `filebeat.yml` template states that authentication is deprecated, however [the official configuration reference](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-reference-yml.html) does not mention this.