### PR TITLE
Replace deprecated 'include:' with 'include_tasks:'

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
-- include: setup-RedHat.yml
+- include_tasks: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'
 
-- include: setup-Debian.yml
+- include_tasks: setup-Debian.yml
   when: ansible_os_family == 'Debian'
 
 - name: Install Filebeat.
@@ -10,7 +10,7 @@
     name: "{{ filebeat_package }}"
     state: "{{ filebeat_package_state }}"
 
-- include: config.yml
+- include_tasks: config.yml
   when: filebeat_create_config | bool
 
 - name: Ensure Filebeat is started and enabled at boot.


### PR DESCRIPTION
Changed from 'include:' to 'include_tasks:' in response to this warning message:
`[DEPRECATION WARNING]: "include" is deprecated, use include_tasks/import_tasks instead. This feature 
will be removed in version 2.16. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.`