### PR TITLE
fix: auth keys are templated onto commented line

### DIFF
--- a/templates/filebeat.yml.j2
+++ b/templates/filebeat.yml.j2
@@ -15,9 +15,9 @@ output:
 
     # Optional auth via API Key or username/password.
     # The options are mutually exclusive and api_key takes the precedence.
-    {%- if 'api_key' in filebeat_output_elasticsearch_auth %}
+    {%- if 'api_key' in filebeat_output_elasticsearch_auth +%}
     api_key: "{{ filebeat_output_elasticsearch_auth.api_key }}"
-    {%- elif 'username' in filebeat_output_elasticsearch_auth %}
+    {%- elif 'username' in filebeat_output_elasticsearch_auth +%}
     username: "{{ filebeat_output_elasticsearch_auth.username }}"
     password: "{{ filebeat_output_elasticsearch_auth.password }}"
     {%- endif %}


### PR DESCRIPTION
When providing elasticsearch auth configuration, the role would template the keys onto the preceding commented line due to overambitious whitespace removal. e.g.:

```
filebeat_output_elasticsearch_auth:
    username: "admin"
    username: "S3CR3eeet"
```
Output:
```
    # The options are mutually exclusive and api_key takes the precedence.    username: "elastic"
    password: "S3CR3eeet"
```
Or input:
```
    filebeat_output_elasticsearch_auth:
      api_key: "xa-123a-f3ea012d-aaae1"
```
Output:
```
# The options are mutually exclusive and api_key takes the precedence.    api_key: "xa-123a-f3ea012d-aaae1"
```

This PR disables whitespace removal at the end of the conditional block so internal whitespace is preserved, as described in the [Jinja Whitespace control docs](https://jinja.palletsprojects.com/en/3.1.x/templates/#whitespace-control).