### PR TITLE
support using already installed system certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,20 @@ Whether to enable Logstash output, and which hosts to send output to.
 
 Filebeat logging.
 
-    filebeat_ssl_dir: /etc/pki/logstash
+    filebeat_ssl_certs_dir: /etc/pki/logstash
+    filebeat_ssl_private_dir: "{{ filebeat_ssl_certs_dir }}"
 
 The path where certificates and keyfiles will be stored.
 
+    filebeat_ssl_ca_file: ""
     filebeat_ssl_certificate_file: ""
     filebeat_ssl_key_file: ""
 
-Local paths to the SSL certificate and key files, which will be copied into the `filebeat_ssl_dir`.
+Local paths to the SSL certificate and key files.
+
+    filebeat_ssl_copy_file: true
+
+Wether to copy certificate and key into the `filebeat_ssl_dir`, or use existing ones.
 
 For utmost security, you should use your own valid certificate and keyfile, and update the `filebeat_ssl_*` variables in your playbook to use your certificate.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,9 +26,12 @@ filebeat_log_level: warning
 filebeat_log_dir: /var/log/mybeat
 filebeat_log_filename: mybeat.log
 
-filebeat_ssl_dir: /etc/pki/logstash
+filebeat_ssl_certs_dir: /etc/pki/logstash
+filebeat_ssl_private_dir: "{{ filebeat_ssl_certs_dir }}"
+filebeat_ssl_ca_file: ""
 filebeat_ssl_certificate_file: ""
 filebeat_ssl_key_file: ""
+filebeat_ssl_copy_files: true
 filebeat_ssl_insecure: "false"
 
 filebeat_elastic_cloud_enabled: false

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -8,22 +8,28 @@
     mode: 0644
   notify: restart filebeat
 
-- name: Ensure Filebeat SSL key pair directory exists.
+- name: Ensure Filebeat SSL directories exist.
   file:
-    path: "{{ filebeat_ssl_dir }}"
+    path: "{{ item }}"
     state: directory
     mode: 0755
+  loop:
+    - filebeat_ssl_certs_dir
+    - filebeat_ssl_private_dir
   when: filebeat_ssl_key_file | default(false)
 
 - name: Copy SSL key and cert for filebeat.
   copy:
-    src: "{{ item }}"
-    dest: "{{ filebeat_ssl_dir }}/{{ item | basename }}"
+    src: "{{ item.file }}"
+    dest: "{{ item.dir }}/{{ item.file | basename }}"
     mode: 0644
   with_items:
-    - "{{ filebeat_ssl_key_file }}"
-    - "{{ filebeat_ssl_certificate_file }}"
+    - "{ dir: {{ filebeat_ssl_private_dir }}, file: {{ filebeat_ssl_key_file }} }"
+    - "{ dir: {{ filebeat_ssl_certs_dir }}, file: {{ filebeat_ssl_certificate_file }} }"
   notify: restart filebeat
   when:
+    - filebeat_ssl_copy_files
     - filebeat_ssl_key_file | default(false)
     - filebeat_ssl_certificate_file | default(false)
+
+#- name: Ensure filebeat can read system's private key

--- a/templates/filebeat.yml.j2
+++ b/templates/filebeat.yml.j2
@@ -64,13 +64,13 @@ output:
     # ssl configuration. By default is off.
     ssl:
       # List of root certificates for HTTPS server verifications
-      certificate_authorities: ["{{ filebeat_ssl_dir }}/{{ filebeat_ssl_certificate_file | basename }}"]
+      certificate_authorities: ["{{ filebeat_ssl_certs_dir }}/{{ filebeat_ssl_ca_file | basename }}"]
 
       # Certificate for TLS client authentication
-      certificate: "{{ filebeat_ssl_dir }}/{{ filebeat_ssl_certificate_file | basename }}"
+      certificate: "{{ filebeat_ssl_certs_dir }}/{{ filebeat_ssl_certificate_file | basename }}"
 
       # Client Certificate Key
-      key: "{{ filebeat_ssl_dir }}/{{ filebeat_ssl_key_file | basename}}"
+      key: "{{ filebeat_ssl_private_dir }}/{{ filebeat_ssl_key_file | basename}}"
 
       # Controls whether the client verifies server certificates and host name.
       # If insecure is set to true, all server host names and certificates will be
@@ -113,13 +113,13 @@ output:
     # ssl configuration. By default is off.
     ssl:
       # List of root certificates for HTTPS server verifications
-      certificate_authorities: ["{{ filebeat_ssl_dir }}/{{ filebeat_ssl_certificate_file | basename }}"]
+      certificate_authorities: ["{{ filebeat_ssl_certs_dir }}/{{ filebeat_ssl_ca_file | basename }}"]
 
       # Certificate for TLS client authentication
-      certificate: "{{ filebeat_ssl_dir }}/{{ filebeat_ssl_certificate_file | basename }}"
+      certificate: "{{ filebeat_ssl_certs_dir }}/{{ filebeat_ssl_certificate_file | basename }}"
 
       # Client Certificate Key
-      key: "{{ filebeat_ssl_dir }}/{{ filebeat_ssl_key_file | basename}}"
+      key: "{{ filebeat_ssl_private_dir }}/{{ filebeat_ssl_key_file | basename}}"
 
       # Controls whether the client verifies server certificates and host name.
       # If insecure is set to true, all server host names and certificates will be


### PR DESCRIPTION
Hi! Hosts on which we deploy filebeat may already have keys and certificates provided by our certificate authority. This MR allows filebeat to make use of them.