### PR TITLE
Configuration of filebeat modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,15 @@ Note that filebeat and logstash may not work correctly with self-signed certific
 
 Set this to `"true"` to allow the use of self-signed certificates (when a CA isn't available).
 
+    filebeat_modules: true
+
+Wether to enable filebeat modules by creating the relevant configuration options.
+
+    filebeat_modules_path: "${path.config}/modules.d/*.yml"
+    filebeat_modules_reload: false
+
+Path of the filebeat modules directory (${path.config} contains the base path to filebeat.yml). If you want to enable automatic reloading of module configuration, you can set filebeat_modules_reload to `"true"`.
+
 ### Overriding the filebeat template
 
 If you can't customize via variables because an option isn't exposed, you can override the template used to generate the filebeat configuration.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,3 +38,7 @@ filebeat_elastic_cloud_enabled: false
 filebeat_elastic_cloud_id: ""
 filebeat_elastic_cloud_username: ""
 filebeat_elastic_cloud_password: ""
+
+filebeat_modules: true
+filebeat_modules_path: "${path.config}/modules.d/*.yml"
+filebeat_modules_reload: false

--- a/templates/filebeat.yml.j2
+++ b/templates/filebeat.yml.j2
@@ -3,6 +3,18 @@ filebeat:
   inputs:
     {{ filebeat_inputs | to_json }}
 
+{% if filebeat_modules %}
+  config.modules:
+    # Glob pattern for configuration loading
+    path: {{ filebeat_modules_path }}
+
+    # Set to true to enable config reloading
+    reload.enabled: {{ filebeat_modules_reload | to_json }}
+
+    # Period on which files under path should be checked for changes
+    #reload.period: 10s
+{% endif %}
+
 # Configure what outputs to use when sending the data collected by the beat.
 # Multiple outputs may be used.
 output:


### PR DESCRIPTION
Hi there,

As I'm using filebeat modules, I'm currently using a custom template for the ansible role. After looking through your repo to see if any configuration options (or jinja template snippets) exist, I noticed they don't and I'm not the first one (fixes #26 - and after creating the PR I also discovered #46 and #48).

This PR does

1. Add a template snippets for the module configuration (the default one that ships with filebeat installation)
2. Makes the snippet dependant on three new variables for the role configuration
3. Adds the aforementioned variables, again with filebeats default values
4. Makes note of the options within README.md

I did a (admittedly really quick) search if `false` would be a better default because of version differences, but AFAICT these corresponding functionality and path values existed like forever so I went with `true`, which resembles the state after a manual filebeat installation anyway. 

Greetings 👋🏻