### PR TITLE
Switch Elasticsearch GPG Key for RedHat setup

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,7 +1,7 @@
 ---
 - name: Add Elasticsearch GPG key.
   rpm_key:
-    key: https://packages.elastic.co/GPG-KEY-elasticsearch
+    key: https://artifacts.elastic.co/GPG-KEY-elasticsearch
     state: present
 
 - name: Add Filebeat repository.


### PR DESCRIPTION
Hello,

last week Elasticsearch updated their GPG Key. Now, this should allow for Filebeat to be installed on Alma Linux 9 and Rocky Linux 9 without degrating the security policies first.
