### PR TITLE
Set minimum Ansible version for deb822_repository

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
   description: Filebeat for Linux.
   company: "Midwestern Mac, LLC"
   license: "license (BSD, MIT)"
-  min_ansible_version: 2.10
+  min_ansible_version: 2.15
   platforms:
     - name: Debian
       versions:


### PR DESCRIPTION
## Summary
- Raise min_ansible_version to 2.15 because the Debian setup now uses ansible.builtin.deb822_repository.

## Validation
- With ansible-core 2.14, the Debian-family setup path fails while resolving ansible.builtin.deb822_repository.
- With ansible-core 2.15, the same path completes successfully.